### PR TITLE
Improve window resizing and reduce border visibility

### DIFF
--- a/UltraWideScreenShare.WinForms/HitTransparentPanel.cs
+++ b/UltraWideScreenShare.WinForms/HitTransparentPanel.cs
@@ -1,0 +1,38 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace UltraWideScreenShare.WinForms
+{
+    internal sealed class HitTransparentPanel : Panel
+    {
+        [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
+        public int EffectiveResizeMargin { get; set; } = 8;
+
+        protected override void WndProc(ref Message m)
+        {
+            const int WM_NCHITTEST = 0x0084;
+            const int HTTRANSPARENT = -1;
+
+            if (m.Msg == WM_NCHITTEST)
+            {
+                var p = PointToClient(Cursor.Position);
+                int mrg = EffectiveResizeMargin;
+
+                bool nearLeft = p.X < mrg;
+                bool nearTop = p.Y < mrg;
+                bool nearRight = (Width - p.X) <= mrg;
+                bool nearBottom = (Height - p.Y) <= mrg;
+
+                if (nearLeft || nearTop || nearRight || nearBottom)
+                {
+                    m.Result = (IntPtr)HTTRANSPARENT; // let MainWindow handle resize
+                    return;
+                }
+            }
+
+            base.WndProc(ref m);
+        }
+    }
+}

--- a/UltraWideScreenShare.WinForms/MainWindow.Designer.cs
+++ b/UltraWideScreenShare.WinForms/MainWindow.Designer.cs
@@ -33,7 +33,7 @@ namespace UltraWideScreenShare.WinForms
         private void InitializeComponent()
         {
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(MainWindow));
-            magnifierPanel = new Panel();
+            magnifierPanel = new HitTransparentPanel();
             SuspendLayout();
 
             //
@@ -74,6 +74,6 @@ namespace UltraWideScreenShare.WinForms
 
         #endregion
 
-        private Panel magnifierPanel;
+        private HitTransparentPanel magnifierPanel;
     }
 }

--- a/UltraWideScreenShare.WinForms/TitleBarWindow.cs
+++ b/UltraWideScreenShare.WinForms/TitleBarWindow.cs
@@ -182,7 +182,26 @@ namespace UltraWideScreenShare.WinForms
 
         protected override void WndProc(ref Message m)
         {
+            const int WM_NCHITTEST = 0x0084;
             const int WM_DPICHANGED = 0x02E0;
+            const int HTTRANSPARENT = -1;
+
+            if (m.Msg == WM_NCHITTEST)
+            {
+                // Compute the same effective resize margin as the main window
+                int margin = Math.Max(6, (int)Math.Round(8f * DeviceDpi / 96f));
+
+                // Convert current cursor to client coordinates
+                var clientPos = PointToClient(Cursor.Position);
+
+                // If cursor is within bottom margin band of title bar, let hit-testing fall through
+                if (clientPos.Y >= this.ClientSize.Height - margin)
+                {
+                    m.Result = (IntPtr)HTTRANSPARENT; // allow main window to receive WM_NCHITTEST
+                    return;
+                }
+            }
+
             if (m.Msg == WM_DPICHANGED)
             {
                 // LOWORD = X dpi, HIWORD = Y dpi (typically equal)


### PR DESCRIPTION
## Summary

This PR addresses two main user-reported issues:

1. **Yellow border visibility during screen sharing** - The yellow border is now changed to a subtle gray color. The yellow border was originally used for self-capture detection with the Desktop Duplication API, but is no longer needed with the Magnification API.

2. **Difficult window resizing** - Window edges can now be easily grabbed for resizing with an 8-pixel hit area (DPI-scaled to minimum 6px), up from the previous 2-pixel border.

## Changes Made

### Border Appearance
- Changed border color from yellow `(255, 221, 0)` to gray `(128, 128, 128)`
- Added conditional rendering for border display
- Reduced visual prominence while maintaining window definition

### Window Resizing Improvements
- Increased resize margin from 2px to 8px (DPI-aware, min 6px)
- Created `HitTransparentPanel` to pass hit-tests through docked child control
- Fixed WndProc message ordering to handle `WM_NCHITTEST` before `base.WndProc()`
- Added hit-test transparency to `TitleBarWindow` bottom edge for top resize
- Fixed transparency deflation to preserve non-transparent outer resize band

### Code Quality Improvements
- Reduced timer frequency from 2ms to 16ms (60 FPS) for better CPU efficiency
- Fixed hook leak in `MagnifierController` by properly disposing `SetWindowsHookEx`
- Added proper DPI scaling for all resize margins

## Technical Details

The primary issue preventing resize was that the docked `magnifierPanel` child control was intercepting `WM_NCHITTEST` messages before the parent Form could handle them. The solution uses `HTTRANSPARENT` to allow hit-tests to fall through to the parent in the outer resize band while preserving full magnification area.

## Testing

- [x] Build succeeds in Release mode
- [x] Application runs without errors
- [x] Window resizing works on all edges (left, right, top, bottom)
- [x] Window resizing works on all corners
- [x] Top edge resize works through detached title bar
- [x] Border appears as subtle gray instead of bright yellow
- [x] Transparency behavior preserved
- [x] DPI scaling works correctly